### PR TITLE
Feature/add agnes

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -32,6 +32,7 @@ func main() {
 	variants = append(variants, &game.Acme{})
 	variants = append(variants, &game.AcesAndKings{})
 	variants = append(variants, &game.AcesSquare{})
+	variants = append(variants, &game.Agnes{})
 	variants = append(variants, &game.Gaps{})
 
 	instance.Display = tui.New(variants)

--- a/game/acesandkings.go
+++ b/game/acesandkings.go
@@ -197,3 +197,8 @@ func (*AcesAndKings) Talon() bool {
 
 // Redeal
 func (*AcesAndKings) Redeal(_ *state.Talon, _ []*state.Tableau) {}
+
+// FoundationBase
+func (*AcesAndKings) FoundationBase() bool {
+	return false
+}

--- a/game/acessquare.go
+++ b/game/acessquare.go
@@ -360,3 +360,8 @@ func (*AcesSquare) Talon() bool {
 
 // Redeal
 func (*AcesSquare) Redeal(_ *state.Talon, _ []*state.Tableau) {}
+
+// FoundationBase
+func (*AcesSquare) FoundationBase() bool {
+	return false
+}

--- a/game/acme.go
+++ b/game/acme.go
@@ -145,3 +145,8 @@ func (*Acme) Talon() bool {
 
 // Redeal
 func (*Acme) Redeal(_ *state.Talon, _ []*state.Tableau) {}
+
+// FoundationBase
+func (*Acme) FoundationBase() bool {
+	return false
+}

--- a/game/agnes.go
+++ b/game/agnes.go
@@ -1,0 +1,203 @@
+package game
+
+import (
+	"log"
+
+	"github.com/shanehowearth/solitaire/state"
+)
+
+// https://en.wikipedia.org/wiki/Agnes_(card_game)
+type Agnes struct{}
+
+// Ensure that Agnes implements game.Variant.
+var _ Variant = (*Agnes)(nil)
+
+// Name - name of the variant.
+func (*Agnes) Name() string {
+	return "Agnes"
+}
+
+// TableauGridSize - The size of the grid required by Agnes.
+func (*Agnes) TableauGridSize() (int, int) {
+	const height = 1
+	const numAgnesTableau = 7
+
+	return height, numAgnesTableau
+}
+
+// Decks - How many decks of cards are required to play Agnes.
+func (*Agnes) Decks() int {
+	return 1
+}
+
+// Reserves - how the reserves are defined.
+// Note that there are no reserves required in a game of Agnes.
+func (*Agnes) Reserves() []state.StackSpec {
+	return []state.StackSpec{}
+}
+
+// Tableau - how the tableau are defined.
+func (*Agnes) Tableau() []state.StackSpec {
+	var agnesRule = func(tableau *state.Stack, card state.SuitedCard) bool {
+		// Handle when the tableau is empty.
+		// Nothing can be added to an empty tableau except when dealing.
+		if (*tableau).Len() == 0 {
+			return false
+		}
+
+		// Get the card currently at the top of the tableau.
+		topCard, err := (*tableau).Top()
+		if err != nil {
+			return false
+		}
+
+		// Allow Kings to go onto Aces (of the same colour).
+		if ((card.Suit+topCard.Suit)%2 == 0) && (topCard.Rank == state.Ace && card.Rank == state.King) {
+			return true
+		}
+
+		// If the card is the same colour, and is one down in rank
+		// then it can go onto the tableau.
+		if ((card.Suit+topCard.Suit)%2 == 0) && (topCard.Rank-card.Rank) == 1 {
+			return true
+		}
+
+		// All other cases the card should not be added to the tableau.
+		return false
+	}
+
+	return []state.StackSpec{
+		{
+			AddRule:   agnesRule,
+			CardCount: [2]int{1, 1},
+			BaseCard:  state.SuitedCard{Rank: state.King},
+		},
+		{
+			AddRule:   agnesRule,
+			CardCount: [2]int{2, 1},
+			BaseCard:  state.SuitedCard{Rank: state.King},
+		},
+		{
+			AddRule:   agnesRule,
+			CardCount: [2]int{3, 1},
+			BaseCard:  state.SuitedCard{Rank: state.King},
+		},
+		{
+			AddRule:   agnesRule,
+			CardCount: [2]int{4, 1},
+			BaseCard:  state.SuitedCard{Rank: state.King},
+		},
+		{
+			AddRule:   agnesRule,
+			CardCount: [2]int{5, 1},
+			BaseCard:  state.SuitedCard{Rank: state.King},
+		},
+		{
+			AddRule:   agnesRule,
+			CardCount: [2]int{6, 1},
+			BaseCard:  state.SuitedCard{Rank: state.King},
+		},
+		{
+			AddRule:   agnesRule,
+			CardCount: [2]int{7, 1},
+			BaseCard:  state.SuitedCard{Rank: state.King},
+		},
+	}
+}
+
+// Foundations - how the foundations are defined.
+func (*Agnes) Foundations() []state.StackSpec {
+	// TODO: The Basecard is set when the first deal happens.
+	return []state.StackSpec{
+		{
+			BaseCard: state.SuitedCard{Rank: state.Ace, Suit: state.Hearts},
+			AddRule:  PlusOneRule,
+		},
+		{
+			BaseCard: state.SuitedCard{Rank: state.Ace, Suit: state.Diamonds},
+			AddRule:  PlusOneRule,
+		},
+		{
+			BaseCard: state.SuitedCard{Rank: state.Ace, Suit: state.Clubs},
+			AddRule:  PlusOneRule,
+		},
+		{
+			BaseCard: state.SuitedCard{Rank: state.Ace, Suit: state.Spades},
+			AddRule:  PlusOneRule,
+		},
+	}
+}
+
+// HasWon - How to tell if the game has been won.
+func (*Agnes) HasWon(_ []*state.Tableau, foundations []*state.Foundation) bool {
+	for _, foundation := range foundations {
+		if foundation.Len() != state.RankCount {
+			return false
+		}
+	}
+
+	return true
+}
+
+// MaxRedeals - how many redeals are allowed.
+func (*Agnes) MaxRedeals() int {
+	// There are 3 redeals allowed
+	return 3
+}
+
+// Move -
+func (*Agnes) Move(source, destination *state.Stack, _ []*state.Tableau) bool {
+	log.Printf("Agnes Move source %s dest %s", source.Base.Rank.String(), destination.Base.Rank.String())
+	log.Printf("Agnes Move source %s dest %s", source.Base.Suit.String(), destination.Base.Suit.String())
+	return Move(source, destination)
+}
+
+// Compact
+func (*Agnes) Compact(_, _ *state.Stack, _ []*state.Tableau) {}
+
+// Talon
+func (*Agnes) Talon() bool {
+	return false
+}
+
+// HowToPlay - Tell the player how to play the game.
+func (*Agnes) HowToPlay() []string {
+	//nolint:lll // Long line needed to preserve readability of game rules text.
+	lines := []string{
+		`After shuffling, twenty-eight cards are dealt, face up, in seven rows and aligned left.[d] The first row has seven cards, the second six cards and so on. The tableau thus forms a right-angled triangle. The twenty-ninth card is turned up and placed above the tableau as the first "master card" (foundation card). The remaining three master cards are those of the same rank as the first and are placed in a row to its right when they become available.[1]
+`,
+		`The aim is to build on the master cards in suit and ascending sequence, turning the corner with the Aces if necessary. The lowest card in each column is "exposed" i.e. available to be moved to a foundation pile or onto the bottom card of the same colour in another column and in descending sequence. Two or more cards may be moved from one column to another as a packet if they are of the same suit as well as the same colour.[e] So the ♠8 can be moved onto the ♣9, but they cannot be moved on together. In addition, any exposed card can be moved into a vacancy in the tableau, but such spaces need not be occupied.[1][f]
+`,
+		`When no more moves are possible on the initial layout, seven more cards are dealt to the bottom of the seven columns, after which any further moves may be carried out. Once all desired moves have been made, another seven cards are dealt to the columns and so on until the pack is exhausted. After the third deal, there will be two cards left in hand which may be looked at before the third deal is played. When all moves have been made, they are dealt to the first two columns.[g] Only one deal is permitted and if any cards remain in the tableau, the patience has failed.[1]
+`,
+	}
+
+	return lines
+}
+
+// Redeal
+func (*Agnes) Redeal(talon *state.Talon, tableau []*state.Tableau) {
+	// Place a card on each of the tableau.
+	for idx := range tableau {
+		top, err := talon.Stock.Top()
+		if err != nil {
+			// No more cards.
+			return
+		}
+
+		// Temporarily set the tableau rule to allow any cards to be added.
+		holdRule := tableau[idx].Stack.Rule
+		tableau[idx].Stack.Rule = func(state.SuitedCard) bool { return true }
+
+		tableau[idx].Stack.Add(top, true)
+
+		_, _ = talon.Stock.Deal()
+		tableau[idx].Stack.Rule = holdRule
+	}
+
+}
+
+// FoundationBase
+func (*Agnes) FoundationBase() bool {
+	return true
+}

--- a/game/agnes.go
+++ b/game/agnes.go
@@ -41,12 +41,12 @@ func (*Agnes) Tableau() []state.StackSpec {
 	var agnesRule = func(tableau *state.Stack, card state.SuitedCard) bool {
 		// Handle when the tableau is empty.
 		// Nothing can be added to an empty tableau except when dealing.
-		if (*tableau).Len() == 0 {
+		if tableau.Len() == 0 {
 			return false
 		}
 
 		// Get the card currently at the top of the tableau.
-		topCard, err := (*tableau).Top()
+		topCard, err := tableau.Top()
 		if err != nil {
 			return false
 		}

--- a/game/gaps.go
+++ b/game/gaps.go
@@ -213,3 +213,8 @@ func (*Gaps) HasWon(tableau []*state.Tableau, _ []*state.Foundation) bool {
 
 	return true
 }
+
+// FoundationBase
+func (*Gaps) FoundationBase() bool {
+	return false
+}

--- a/game/klondike.go
+++ b/game/klondike.go
@@ -34,7 +34,6 @@ func (*Klondike) Reserves() []state.StackSpec {
 
 // Tableau - how the tableau are defined.
 func (*Klondike) Tableau() []state.StackSpec {
-	// return numKlondikeTableau, state.King, MinusOneRule
 	return []state.StackSpec{
 		{
 			AddRule:   MinusOneRule,
@@ -154,3 +153,8 @@ func (*Klondike) Talon() bool {
 
 // Redeal
 func (*Klondike) Redeal(_ *state.Talon, _ []*state.Tableau) {}
+
+// FoundationBase
+func (*Klondike) FoundationBase() bool {
+	return false
+}

--- a/game/klondike_vegas.go
+++ b/game/klondike_vegas.go
@@ -157,3 +157,8 @@ func (*KlondikeVegas) Talon() bool {
 
 // Redeal
 func (*KlondikeVegas) Redeal(_ *state.Talon, _ []*state.Tableau) {}
+
+// FoundationBase
+func (*KlondikeVegas) FoundationBase() bool {
+	return false
+}

--- a/game/move.go
+++ b/game/move.go
@@ -45,25 +45,25 @@ func Move(source, destination *state.Stack) bool {
 
 	// This loop attempts to find the group of cards that may be moved.
 	for {
-		top, err := source.Top()
+		sourceTop, err := source.Top()
 		if err != nil {
 			break
 		}
 
-		if !top.Visible && (source.Type != state.StackTalon) {
+		if !sourceTop.Visible && (source.Type != state.StackTalon) {
 			break
 		}
 
 		count++
 
-		temp.Add(top, true)
+		temp.Add(sourceTop, true)
 
 		_, err = source.Deal()
 		if err != nil {
 			log.Printf("Stack Deal err %v", err)
 		}
 
-		if destination.Rule(top) && destination.Type != state.StackTalon {
+		if destination.Rule(sourceTop) && destination.Type != state.StackTalon {
 			canMove = true
 			break
 		}
@@ -95,10 +95,10 @@ func Move(source, destination *state.Stack) bool {
 	}
 
 	if !canMove {
-		savedRule := source.Rule
-		source.Rule = func(state.SuitedCard) bool { return true }
 		// Put the cards back and finish.
 		for {
+			savedRule := source.Rule
+			source.Rule = func(state.SuitedCard) bool { return true }
 			top, err := temp.Top()
 			if err != nil {
 				source.Rule = savedRule

--- a/game/move.go
+++ b/game/move.go
@@ -22,7 +22,11 @@ func Move(source, destination *state.Stack) bool {
 	temp := state.NewStack(
 		source.Len(),
 		state.SuitedCard{},
-		func(state.SuitedCard) bool { return true },
+		func(*state.Stack) func(state.SuitedCard) bool {
+			return func(state.SuitedCard) bool {
+				return true
+			}
+		},
 		state.StackUndefined,
 	)
 
@@ -150,8 +154,6 @@ func Move(source, destination *state.Stack) bool {
 			source.Add(newTop, true)
 		}
 	}
-
-	//
 
 	return true
 }

--- a/game/move.go
+++ b/game/move.go
@@ -98,12 +98,54 @@ func Move(source, destination *state.Stack) bool {
 		}
 	}
 
+	// Check that all the cards on the temp stack can be moved.
+	// This fixes a bug where the temp stack might have the top card ok to be
+	// moved, but some of the cards beneath it don't belong.
+	temp2 := state.NewStack(
+		source.Len(),
+		state.SuitedCard{},
+		func(*state.Stack) func(state.SuitedCard) bool {
+			return func(state.SuitedCard) bool {
+				return true
+			}
+		},
+		state.StackUndefined,
+	)
+
+	if canMove && temp.Len() > 0 {
+		// Clone the destination for testing
+		testDest := destination.Clone()
+
+		// Try placing cards directly on the cloned destination
+		sequenceValid := true
+		for i := temp.Len() - 1; i >= 0; i-- {
+			card, _ := temp.Deal()
+			temp2.Add(card, true)
+
+			if !testDest.Rule(card) {
+				sequenceValid = false
+				break
+			}
+
+			testDest.Add(card, true) // Add to test next card
+		}
+
+		// Save remaining cards from temp if we broke early
+		for temp.Len() > 0 {
+			card, _ := temp.Deal()
+			temp2.Add(card, true)
+		}
+		canMove = sequenceValid
+	}
+
+	temp2.Reverse()
+
 	if !canMove {
 		// Put the cards back and finish.
 		for {
 			savedRule := source.Rule
 			source.Rule = func(state.SuitedCard) bool { return true }
-			top, err := temp.Top()
+			top, err := temp2.Top()
 			if err != nil {
 				source.Rule = savedRule
 				break
@@ -111,8 +153,6 @@ func Move(source, destination *state.Stack) bool {
 
 			stackTop, _ := source.Top()
 			if stackTop.Rank == top.Rank && stackTop.Suit == top.Suit {
-				log.Printf("Got same card %v %v", stackTop, top)
-
 				source.Rule = savedRule
 
 				break
@@ -124,13 +164,28 @@ func Move(source, destination *state.Stack) bool {
 				source.Add(top, true)
 			}
 
+			_, _ = temp2.Deal()
+		}
+
+		// Then, restore any cards still in temp
+		for {
+			top, err := temp.Top()
+			if err != nil {
+				break
+			}
+
+			if source.Type == state.StackTalon {
+				source.Add(top, false)
+			} else {
+				source.Add(top, true)
+			}
 			_, _ = temp.Deal()
 		}
 	} else {
 		// If the card can be added to the destination add it, and drop it from the
 		// source.
 		for {
-			top, err := temp.Top()
+			top, err := temp2.Top()
 			if err != nil {
 				break
 			}
@@ -141,7 +196,7 @@ func Move(source, destination *state.Stack) bool {
 				destination.Add(top, true)
 			}
 			// Pull the top card off the source stack.
-			_, _ = temp.Deal()
+			_, _ = temp2.Deal()
 		}
 		// Make the top card visible.
 		if source.Type == state.StackTableau || source.Type == state.StackReserve {

--- a/game/redeal.go
+++ b/game/redeal.go
@@ -9,7 +9,11 @@ func GapsRedeal(tableau []*state.Tableau, rowCount, colCount int) {
 	cardsToShuffle := state.NewStack(
 		rowCount,
 		state.SuitedCard{},
-		func(state.SuitedCard) bool { return true },
+		func(*state.Stack) func(state.SuitedCard) bool {
+			return func(state.SuitedCard) bool {
+				return true
+			}
+		},
 		state.StackUndefined,
 	)
 

--- a/game/variant.go
+++ b/game/variant.go
@@ -39,6 +39,10 @@ type Variant interface {
 	// cleared, cards are moved to the foundations.
 	Foundations() []state.StackSpec
 
+	// FoundationBase - tell the first deal whether to use a card from the stock
+	// as the base, or not.
+	FoundationBase() bool
+
 	// HowToPlay - Explains to the player how the game is played.
 	HowToPlay() []string
 

--- a/gamestate.go
+++ b/gamestate.go
@@ -26,8 +26,10 @@ func (instance *Instance) setupGameState() {
 		instance.Game.MaxRedeals(),
 		1, // how many cards per deal.
 		// Talon rule is to allow everything to be added to its stacks.
-		func(state.SuitedCard) bool {
-			return true
+		func(*state.Stack) func(state.SuitedCard) bool {
+			return func(state.SuitedCard) bool {
+				return true
+			}
 		},
 	)
 

--- a/solitaire.go
+++ b/solitaire.go
@@ -89,6 +89,9 @@ func (instance *Instance) onComponentSelected(
 		fromStack = instance.Tableau[fromIndex].Stack
 	case state.StackTalon:
 		fromStack = instance.Talon.Stock
+		if !instance.Game.Talon() {
+			return
+		}
 	case state.StackWaste:
 		fromStack = instance.Talon.Waste
 	case state.StackReserve:

--- a/solitaire.go
+++ b/solitaire.go
@@ -195,6 +195,34 @@ func (instance *Instance) dealCards() {
 		instance.Talon.Waste.Add(card, true)
 	}
 
+	if instance.Game.FoundationBase() {
+		card := instance.Deck.Deal()
+		toChange := 99
+		switch card.Suit {
+		case state.Hearts:
+			toChange = 0
+		case state.Diamonds:
+			toChange = 1
+		case state.Clubs:
+			toChange = 2
+		case state.Spades:
+			toChange = 3
+		}
+
+		backUpRule := instance.Foundations[toChange].Stack.Rule
+		instance.Foundations[toChange].Stack.Rule = func(state.SuitedCard) bool { return true }
+		instance.Foundations[toChange].Stack.Add(card, true)
+		instance.Foundations[0].Base = state.SuitedCard{Rank: card.Rank, Suit: state.Hearts}
+		instance.Foundations[1].Base = state.SuitedCard{Rank: card.Rank, Suit: state.Diamonds}
+		instance.Foundations[2].Base = state.SuitedCard{Rank: card.Rank, Suit: state.Clubs}
+		instance.Foundations[3].Base = state.SuitedCard{Rank: card.Rank, Suit: state.Spades}
+		instance.Foundations[0].Stack.Base = state.SuitedCard{Rank: card.Rank, Suit: state.Hearts}
+		instance.Foundations[1].Stack.Base = state.SuitedCard{Rank: card.Rank, Suit: state.Diamonds}
+		instance.Foundations[2].Stack.Base = state.SuitedCard{Rank: card.Rank, Suit: state.Clubs}
+		instance.Foundations[3].Stack.Base = state.SuitedCard{Rank: card.Rank, Suit: state.Spades}
+		instance.Foundations[toChange].Stack.Rule = backUpRule
+	}
+
 	// Put the rest of the cards onto the talon.
 	for instance.Deck.Len() != 0 {
 		card := instance.Deck.Deal()

--- a/state/foundation.go
+++ b/state/foundation.go
@@ -33,8 +33,10 @@ func CreateFoundations(foundationSpec []StackSpec) []*Foundation {
 
 		stack := NewStack(RankCount,
 			foundationSpec[i].BaseCard,
-			func(card SuitedCard) bool {
-				return foundationSpec[i].AddRule(foundation.Stack, card)
+			func(foundationStack *Stack) func(SuitedCard) bool {
+				return func(card SuitedCard) bool {
+					return foundationSpec[i].AddRule(foundationStack, card)
+				}
 			},
 			StackFoundation,
 		)

--- a/state/game.go
+++ b/state/game.go
@@ -22,7 +22,7 @@ func New(
 	// Talon Setup.
 	dealCount int,
 	perDealCount int,
-	talonRule func(SuitedCard) bool,
+	talonRule func(*Stack) func(SuitedCard) bool,
 ) *State {
 	return &State{
 		Deck: CreateDecks(decks),

--- a/state/move.go
+++ b/state/move.go
@@ -37,3 +37,21 @@ func (stack *Stack) Deal() (SuitedCard, error) {
 func (stack *Stack) Reverse() {
 	slices.Reverse(*stack.cards)
 }
+
+func (stack *Stack) Clone() *Stack {
+	clone := NewStack(
+		stack.Len(),
+		stack.Base,
+		stack.ruleFactory,
+		stack.Type,
+	)
+
+	cards := make([]SuitedCard, stack.Len())
+	for idx := 0; idx < stack.Len(); idx++ {
+		cards[idx] = (*stack.cards)[idx]
+	}
+
+	clone.cards = &cards
+
+	return clone
+}

--- a/state/reserve.go
+++ b/state/reserve.go
@@ -23,8 +23,10 @@ func CreateReserves(reserveSpec []StackSpec) []*Reserve {
 
 		stack := NewStack(RankCount,
 			reserveSpec[i].BaseCard,
-			func(card SuitedCard) bool {
-				return reserveSpec[i].AddRule(reserve.Stack, card)
+			func(targetStack *Stack) func(SuitedCard) bool {
+				return func(card SuitedCard) bool {
+					return reserveSpec[i].AddRule(targetStack, card)
+				}
 			},
 			StackReserve,
 		)

--- a/state/stack.go
+++ b/state/stack.go
@@ -11,6 +11,7 @@ type Stack struct {
 	cards           *[]SuitedCard
 	Base            SuitedCard
 	Rule            func(SuitedCard) bool
+	ruleFactory     func(*Stack) func(SuitedCard) bool
 	Type            StackType
 	Received        int // count how many times this stack has received cards.
 	MaxRedeals      int
@@ -41,15 +42,28 @@ const (
 
 // NewStack - Create a new stack with an empty slice of SuitedCards that has a
 // capacity of n.
-func NewStack(number int, base SuitedCard, rule func(SuitedCard) bool, componentType StackType) *Stack {
+func NewStack(
+	number int,
+	base SuitedCard,
+	// rule func(SuitedCard) bool,
+	ruleFactory func(*Stack) func(SuitedCard) bool,
+	componentType StackType,
+) *Stack {
 	cards := make([]SuitedCard, 0, number)
 
-	return &Stack{
-		Base:  base,
-		cards: &cards,
-		Rule:  rule,
-		Type:  componentType,
+	stack := &Stack{
+		Base:        base,
+		cards:       &cards,
+		ruleFactory: ruleFactory,
+		Type:        componentType,
 	}
+
+	// Create the actual rule using the factory
+	if ruleFactory != nil {
+		stack.Rule = ruleFactory(stack)
+	}
+
+	return stack
 }
 
 // Len - return the length of the stack.
@@ -64,6 +78,14 @@ func (stack *Stack) Top() (SuitedCard, error) {
 	}
 
 	return (*stack.cards)[stack.Len()-1], nil
+}
+
+// RebindRule -
+func (stack *Stack) RebindRule(targetStack *Stack) {
+	if stack.ruleFactory != nil {
+		targetStack.Rule = stack.ruleFactory(targetStack)
+		targetStack.ruleFactory = stack.ruleFactory
+	}
 }
 
 const blankCard = "--"

--- a/state/tableau.go
+++ b/state/tableau.go
@@ -26,10 +26,13 @@ func CreateTableaus(tableauSpec []StackSpec) []*Tableau {
 			Base: tableauSpec[idx].BaseCard.Rank,
 		}
 
-		stack := NewStack(RankCount,
+		stack := NewStack(
+			RankCount,
 			tableauSpec[idx].BaseCard,
-			func(card SuitedCard) bool {
-				return tableauSpec[idx].AddRule(tableau.Stack, card)
+			func(targetStack *Stack) func(SuitedCard) bool {
+				return func(card SuitedCard) bool {
+					return tableauSpec[idx].AddRule(targetStack, card)
+				}
 			},
 			StackTableau,
 		)

--- a/state/talon.go
+++ b/state/talon.go
@@ -20,16 +20,18 @@ type Talon struct {
 // NewTalon - Create a new talon.
 func NewTalon(
 	dealCount, perDealCount int,
-	rule func(SuitedCard) bool,
+	ruleFactory func(*Stack) func(SuitedCard) bool,
 ) *Talon {
 	const stackSize = 52
 
 	stock := NewStack(
 		stackSize,
 		SuitedCard{},
-		func(SuitedCard) bool {
-			// Let anything on.
-			return true
+		func(targetStack *Stack) func(SuitedCard) bool {
+			return func(card SuitedCard) bool {
+				// Let anything on.
+				return true
+			}
 		},
 		StackTalon,
 	)
@@ -39,7 +41,7 @@ func NewTalon(
 	waste := NewStack(
 		stackSize,
 		SuitedCard{},
-		rule,
+		ruleFactory,
 		StackWaste,
 	)
 


### PR DESCRIPTION
Add the Agnes variant

This changed required a rethink about validation and moving multiple cards at once, because there will be instances where the top card in a subset of cards on a stack can go onto another stack BUT cards lower down in the substack shouldn't be moved.

A clone and rule rebinding methods needed to be added to the stack - this should also make a future "Undo" functionality easier to do.