### PR TITLE
Waste piles can only accept cards from the talon

### DIFF
--- a/game/acessquare.go
+++ b/game/acessquare.go
@@ -256,6 +256,10 @@ func (*AcesSquare) MaxRedeals() int {
 
 // Move -
 func (*AcesSquare) Move(first, second *state.Stack, _ []*state.Tableau) bool {
+	if second.Type == state.StackWaste && first.Type != state.StackTalon {
+		return false
+	}
+
 	// Are the first and second "touching"
 	// first.
 	firstCard, err := first.Top()

--- a/game/gaps.go
+++ b/game/gaps.go
@@ -103,6 +103,11 @@ func (*Gaps) Move(source, destination *state.Stack, tableau []*state.Tableau) bo
 		return false
 	}
 
+	// Waste can only accept cards from the talon.
+	if destination.Type == state.StackWaste && source.Type != state.StackTalon {
+		return false
+	}
+
 	// Only one card per tableau.
 	if destination.Len() > 0 {
 		return false

--- a/game/move.go
+++ b/game/move.go
@@ -17,6 +17,11 @@ func Move(source, destination *state.Stack, keepSequence bool) bool {
 		return false
 	}
 
+	if destination.Type == state.StackWaste && source.Type != state.StackTalon {
+		// Waste can only receive cards from the stock.
+		return false
+	}
+
 	// Can we move multiple cards?
 	// Temporary stack that will hold cards that will be moved.
 	temp := state.NewStack(


### PR DESCRIPTION
A bug was discovered where cards from any pile could be put onto the waste - thus allowing moves that shouldn't have been happening.